### PR TITLE
Simplified protocol further by eliminating threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ There are three contracts:
 
 The flow is like so:
 
-1. A user creates a proposal request on a GovernorBranch. The request includes a list of calls. A hash of the proposal is sent to the GovernorRoot as the "executionHash"
-2. The GovernorRoot receives the proposal request and creates a new proposal hash, which includes the execution hash and the start epoch and end timestamp.
-3. Users submit their votes to each GovernorBranch. The root does not need to signal to the branch; users submit all data required to generate the proposal hash.
-4. After the end timestamp, the GovernorBranch can submit the vote totals to the GovernorRoot.
-5. If the proposal passes (grace period ends and quorum is met) anyone can tell the GovernorRoot to send the "queueProposal" message to a branch. This message includes the proposal hash. The message only needs to be sent to branches that have calls to execute. The GovernorBranch records the proposal hash as queued.
-6. Anyone can submit the full execution details to a GovernorBranch to execute the contents of a proposal.
+1. Users submit their votes for a proposal to each GovernorBranch.
+2. After the end timestamp, the GovernorBranch can submit the vote totals to the GovernorRoot.
+3. If the proposal passes (grace period ends and quorum is met) anyone can tell the GovernorRoot to send the "queueProposal" message to a branch. This message includes the proposal hash. The message only needs to be sent to branches that have calls to execute. The GovernorBranch records the proposal hash as queued.
+4. Anyone can submit the full execution details to a GovernorBranch to execute the contents of a proposal.
 
 To see the above flow in action please refer to the [end-to-end integration test](./src/test/Integration.t.sol)
 
@@ -23,11 +21,8 @@ To see the above flow in action please refer to the [end-to-end integration test
 
 You can see how this design separates execution from consensus. Inter-chain communication is minimized to the messages:
 
-- Proposal request from the GovernorBranch to the GovernorRoot.
-- Submit vote totals from all GovernorBranches to the GovernorRoot.
+- Submit vote totals from GovernorBranches to the GovernorRoot.
 - Queue proposal from the GovernorRoot to only GovernorBranches that require execution.
-
-
 
 # Development
 

--- a/src/interfaces/IGovernorRoot.sol
+++ b/src/interfaces/IGovernorRoot.sol
@@ -1,14 +1,12 @@
 pragma solidity 0.8.10;
 
 interface IGovernorRoot {
-
-    function requestProposal(bytes32 executionHash) external returns (bool);
-
     function addVotes(
         uint256 againstVotes,
         uint256 forVotes,
         uint256 abstainVotes,
-        bytes32 proposalHash
+        bytes32 executionHash,
+        uint32 epoch,
+        uint64 endTimestamp
     ) external returns (bool);
-
 }


### PR DESCRIPTION
The "threshold" is the minimum amount of voting power a user must have to create a proposal.

For cross-chain proposals, this is actually quite complicated to check.  What if a user has split their tokens?  By eliminating this requirement, we can simplify the spec significantly. We no longer need a requestProposal / createProposal flow.

The threshold can still be implemented but as a *visual* assistance; i.e. filter out proposal with fewer than X amount of votes.  This makes the threshold more like the ERC20 token `decimals` in that it's important but only for visual purposes (don't show spammy proposals).

The change reduces the cross-chain messaging to the bare minimum:

1. Each gov branch sends its aggregate votes to the gov root
2. The gov root sends the proposal hash to only the gov branches that need to execute txs in the proposal.
